### PR TITLE
docs: requirements.txt 버전 오류 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ constantly==15.1.0
 contourpy==1.0.7
 coreapi==2.3.3
 coreschema==0.0.4
-cryptography==41.0.2
+cryptography==37.0.0
 cycler==0.11.0
 daphne==4.0.0
 debugpy==1.6.7


### PR DESCRIPTION
EC2에서 배포할 때 cryptography 버전 부분이 최신버전이라 오류가 나는거 같아서 이전 버전으로 수정해서 올렸습니다.